### PR TITLE
Changed middleware name to be easily used outside

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict'
 
 exports.Logger = require('./lib/logger').Logger
-exports.middleware = require('./lib/middleware').middleware
+exports.loggerMiddleware = require('./lib/middleware').middleware


### PR DESCRIPTION
This way the syntax
```javascript
const { loggerMiddleware } = require('@first-lego-league/ms-logger')
app.use(loggerMiddleware)
```
Is more readable